### PR TITLE
fix: drop Git LFS from dimensioning publish flow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,0 @@
-# Git LFS tracking for large xcframeworks
-# MVDimensioningCore is ~226 MB and exceeds GitHub's 100 MB per-file limit.
-# VisionSDK.xcframework and TensorFlowLiteC.xcframework are under the limit
-# and remain as regular git objects.
-Sources/MVDimensioningCore.xcframework/** filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,14 +43,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          lfs: true
 
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git lfs install
 
       - name: Download core xcframework
         run: |
@@ -117,15 +114,6 @@ jobs:
           echo "Dimensioning bundle unpacked."
           ls Sources/VisionSDKDimensioning/
           ls Sources/MVDimensioningCore.xcframework/
-
-      - name: Track large files with Git LFS
-        if: steps.payload.outputs.has_dimensioning == 'true'
-        run: |
-          # Ensure LFS tracks the MVDimensioningCore binary and any future large xcframeworks.
-          # VisionSDK.xcframework and TensorFlowLiteC.xcframework are under the 100 MB limit
-          # and remain as regular git objects (no change to existing behavior).
-          git lfs track "Sources/MVDimensioningCore.xcframework/**"
-          git add .gitattributes
 
       - name: Bump podspec version
         run: |


### PR DESCRIPTION
Follow-up to #9. The v2.2.4 publish workflow failed at the Push step with `Git LFS is disabled for this repository.`. LFS isn't enabled on this repo and isn't actually needed - the largest file in MVDimensioningCore.xcframework is 67 MB, under GitHub's 100 MB per-file limit. The upstream vision-sdk-ios already commits the same xcframework without LFS.

Removes:
- `with: lfs: true` from the checkout
- `git lfs install` from configure step
- "Track large files with Git LFS" step entirely
- `.gitattributes` (only contained LFS rules)