### PR TITLE
fix: add top-level s.platform to podspec for trunk validation

### DIFF
--- a/VisionSDK.podspec
+++ b/VisionSDK.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://github.com/packagexlabs/vision-sdk'
   s.author           = { 'PackageX' => 'engineering@packagex.io' }
   s.swift_version    = '5.0'
+  s.platform         = :ios, '13.0'
   s.source           = { :git => 'https://github.com/packagexlabs/vision-sdk.git', :tag => s.version.to_s }
   s.default_subspecs = 'Core'
 


### PR DESCRIPTION
Follow-up to #9 + #10. The v2.2.4 trunk validation failed with `source: Unsupported type String, expected Hash` because the podspec had no top-level `s.platform` declaration, resulting in an all-null platforms JSON field. Adding `s.platform = :ios, '13.0'` at the spec root fixes the validation.