### PR TITLE
fix: restore s.source hash, add top-level platform, tighten bump-sed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,9 +118,12 @@ jobs:
       - name: Bump podspec version
         run: |
           VERSION="${{ steps.payload.outputs.version }}"
-          sed -i '' "/s\.version/s/=.*$/= '${VERSION}'/" VisionSDK.podspec
+          # Anchor to the actual `s.version = '...'` declaration. The previous
+          # `/s\.version/` regex also matched the source line, which contains
+          # `:tag => s.version.to_s`, and corrupted `s.source` to `'<version>'`.
+          sed -i '' -E "s/^([[:space:]]*s\.version[[:space:]]*=).*\$/\1 '${VERSION}'/" VisionSDK.podspec
           echo "Podspec version bumped to $VERSION"
-          grep "s.version" VisionSDK.podspec
+          grep -E "^[[:space:]]*s\.version" VisionSDK.podspec
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer

--- a/VisionSDK.podspec
+++ b/VisionSDK.podspec
@@ -13,7 +13,8 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://github.com/packagexlabs/vision-sdk'
   s.author           = { 'PackageX' => 'engineering@packagex.io' }
   s.swift_version    = '5.0'
-  s.source           = '2.2.4'
+  s.platform         = :ios, '13.0'
+  s.source           = { :git => 'https://github.com/packagexlabs/vision-sdk.git', :tag => s.version.to_s }
   s.default_subspecs = 'Core'
 
   # --- Core subspec ---


### PR DESCRIPTION
Follow-up to #9, #10. The v2.2.4 trunk push failed with `source: Unsupported type 'String', expected 'Hash'` because the publish.yml's bump-sed matched too broadly and corrupted the source line. This PR fixes the regex and restores the correct source hash, plus adds a top-level platform.