### PR TITLE
fix: give Dimensioning subspec its own module + drop monolith flag

### DIFF
--- a/VisionSDK.podspec
+++ b/VisionSDK.podspec
@@ -30,24 +30,22 @@ Pod::Spec.new do |s|
   end
 
   # --- Dimensioning subspec ---
-  # Compiles the dimensioning wrapper Swift sources into the *VisionSDK* module
-  # (no module_name override -- inherits parent spec name). Consumers use
-  #   import VisionSDK
-  # and get VSDKDimensioning, VSDKDimensioningView, etc. directly.
+  # Dimensioning ships as its own Swift module (`VisionSDKDimensioning`)
+  # built from source against the prebuilt Core xcframework. The wrapper
+  # Swift files use `@_spi(VSDKDimensioning) import VisionSDK` to access
+  # Core's SPI types. Consumers import the module explicitly:
+  #   import VisionSDKDimensioning
   #
   # Sources land in Sources/VisionSDKDimensioning/ after publish.yml unpacks
   # VisionSDKDimensioning-bundle.zip from the vision-sdk-ios release.
-  # MVDimensioningCore.xcframework (226 MB) is stored via Git LFS.
   s.subspec 'Dimensioning' do |d|
     d.dependency 'VisionSDK/Core'
     d.dependency 'PostHog', '~> 3.0'
     d.ios.deployment_target = '17.0'
+    d.module_name           = 'VisionSDKDimensioning'
     d.source_files          = 'Sources/VisionSDKDimensioning/*.swift'
     d.vendored_frameworks   = 'Sources/MVDimensioningCore.xcframework'
     d.resources             = 'Sources/MVDimensioning.mlmodelkey'
     d.frameworks            = ['ARKit', 'RealityKit', 'CoreML']
-    d.pod_target_xcconfig   = {
-      'OTHER_SWIFT_FLAGS' => '$(inherited) -DVSDK_DIMENSIONING_MONOLITH'
-    }
   end
 end


### PR DESCRIPTION
v2.2.5 trunk publish failed at `pod lib lint` integration build: the wrapper Swift sources couldn't find Core's SPI types (`VSDKDimensioningCredentials`, `VSDKDimensioningTelemetry`, `VSDKDimensioningTelemetryEvent`) because the monolith compile flag bypasses the explicit `import VisionSDK` statements those files need when Core is a sealed prebuilt module.

This PR drops the monolith flag and gives Dimensioning its own `module_name` so the source files can compile in their own translation unit and reach Core via the existing `@_spi(VSDKDimensioning) import VisionSDK` lines.