### PR TITLE
fix: vendor VisionSDKDimensioning.xcframework instead of compiling sources

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,28 +91,32 @@ jobs:
           fi
 
           # Clear old dimensioning artifacts
-          rm -rf Sources/MVDimensioningCore.xcframework Sources/VisionSDKDimensioning
+          rm -rf Sources/MVDimensioningCore.xcframework \
+                 Sources/VisionSDKDimensioning.xcframework \
+                 Sources/VisionSDKDimensioning
           rm -f Sources/MVDimensioning.mlmodelkey
 
           # Unpack. Bundle structure (from release.yml):
           #   dimensioning-bundle/
-          #     MVDimensioningCore.xcframework/
+          #     VisionSDKDimensioning.xcframework/  (compiled wrapper module)
+          #     MVDimensioningCore.xcframework/     (vendored ARKit/LiDAR binary)
           #     MVDimensioning.mlmodelkey
-          #     VisionSDKDimensioning/*.swift
+          #     VisionSDKDimensioning/*.swift       (sources, for reference)
           unzip -o VisionSDKDimensioning-bundle.zip -d /tmp/dim-bundle/
 
-          # Move into Sources/
+          # Move xcframeworks + key into Sources/. The podspec vendors both
+          # xcframeworks; the raw Swift sources stay in the bundle for any
+          # future source-distribution consumer but aren't referenced here.
+          cp -a /tmp/dim-bundle/dimensioning-bundle/VisionSDKDimensioning.xcframework \
+                Sources/
           cp -a /tmp/dim-bundle/dimensioning-bundle/MVDimensioningCore.xcframework \
                 Sources/
           cp    /tmp/dim-bundle/dimensioning-bundle/MVDimensioning.mlmodelkey \
                 Sources/
-          mkdir -p Sources/VisionSDKDimensioning
-          cp    /tmp/dim-bundle/dimensioning-bundle/VisionSDKDimensioning/*.swift \
-                Sources/VisionSDKDimensioning/
 
           rm -rf /tmp/dim-bundle
           echo "Dimensioning bundle unpacked."
-          ls Sources/VisionSDKDimensioning/
+          ls Sources/VisionSDKDimensioning.xcframework/
           ls Sources/MVDimensioningCore.xcframework/
 
       - name: Bump podspec version

--- a/VisionSDK.podspec
+++ b/VisionSDK.podspec
@@ -30,21 +30,21 @@ Pod::Spec.new do |s|
   end
 
   # --- Dimensioning subspec ---
-  # Dimensioning ships as its own Swift module (`VisionSDKDimensioning`)
-  # built from source against the prebuilt Core xcframework. The wrapper
-  # Swift files use `@_spi(VSDKDimensioning) import VisionSDK` to access
-  # Core's SPI types. Consumers import the module explicitly:
+  # Dimensioning ships as a prebuilt xcframework (its own `VisionSDKDimensioning`
+  # Swift module). Consumers import it explicitly:
   #   import VisionSDKDimensioning
   #
-  # Sources land in Sources/VisionSDKDimensioning/ after publish.yml unpacks
-  # VisionSDKDimensioning-bundle.zip from the vision-sdk-ios release.
+  # CocoaPods does not allow `module_name` on subspecs, so we use the
+  # xcframework's own module identity instead of compiling source files.
+  # publish.yml unpacks the xcframeworks from VisionSDKDimensioning-bundle.zip.
   s.subspec 'Dimensioning' do |d|
     d.dependency 'VisionSDK/Core'
     d.dependency 'PostHog', '~> 3.0'
     d.ios.deployment_target = '17.0'
-    d.module_name           = 'VisionSDKDimensioning'
-    d.source_files          = 'Sources/VisionSDKDimensioning/*.swift'
-    d.vendored_frameworks   = 'Sources/MVDimensioningCore.xcframework'
+    d.vendored_frameworks   = [
+      'Sources/VisionSDKDimensioning.xcframework',
+      'Sources/MVDimensioningCore.xcframework'
+    ]
     d.resources             = 'Sources/MVDimensioning.mlmodelkey'
     d.frameworks            = ['ARKit', 'RealityKit', 'CoreML']
   end


### PR DESCRIPTION
v2.2.6 trunk push failed with `Can't set module_name attribute for subspecs`. CocoaPods doesn't allow that, so the source-files approach can't work as designed. Switching to vendor the prebuilt xcframework that release.yml already builds and bundles.